### PR TITLE
Non-execution run fix

### DIFF
--- a/dkube/sdk/internal/api_base.py
+++ b/dkube/sdk/internal/api_base.py
@@ -70,7 +70,10 @@ class ApiBase(object):
         self._api.jobs_list_delete_by_class(user, category, {'jobs': [name]})
 
     def create_run(self, run):
-        response = self._api.jobs_add_one(user=run.user, data=run.job, run='true', execute=run.execute)
+        if type(run) == DkubeTraining:
+            response = self._api.jobs_add_one(user=run.user, data=run.job, run='true', execute=run.execute)
+        else:
+            response = self._api.jobs_add_one(user=run.user, data=run.job, run='true')
 
     def get_run(self, category, user, name, fields='*'):
         response = self._api.jobs_get_collection_one(user, category, name)

--- a/dkube/sdk/internal/api_base.py
+++ b/dkube/sdk/internal/api_base.py
@@ -14,7 +14,6 @@ from dkube.sdk.internal.dkube_api.rest import ApiException
 from dkube.sdk.rsrcs.featureset import DKubeFeatureSetUtils
 from dkube.sdk.rsrcs.training import DkubeTraining
 from dkube.sdk.rsrcs.util import list_of_strs
-from dkube.sdk.rsrcs.util import list_of_strs
 from url_normalize import url_normalize
 
 # Configure API key authorization: d3apikey

--- a/dkube/sdk/internal/api_base.py
+++ b/dkube/sdk/internal/api_base.py
@@ -12,6 +12,8 @@ from dkube.sdk.internal.dkube_api.models.feature_set_commit_def_job import \
     FeatureSetCommitDefJob
 from dkube.sdk.internal.dkube_api.rest import ApiException
 from dkube.sdk.rsrcs.featureset import DKubeFeatureSetUtils
+from dkube.sdk.rsrcs.training import DkubeTraining
+from dkube.sdk.rsrcs.util import list_of_strs
 from dkube.sdk.rsrcs.util import list_of_strs
 from url_normalize import url_normalize
 

--- a/dkube/sdk/internal/api_base.py
+++ b/dkube/sdk/internal/api_base.py
@@ -71,7 +71,7 @@ class ApiBase(object):
         self._api.jobs_list_delete_by_class(user, category, {'jobs': [name]})
 
     def create_run(self, run):
-        if type(run) == DkubeTraining:
+        if hasattr(run, 'execute'):
             response = self._api.jobs_add_one(user=run.user, data=run.job, run='true', execute=run.execute)
         else:
             response = self._api.jobs_add_one(user=run.user, data=run.job, run='true')

--- a/dkube/sdk/rsrcs/preprocessing.py
+++ b/dkube/sdk/rsrcs/preprocessing.py
@@ -70,6 +70,7 @@ class DkubePreprocessing(object):
         self.job = JobModel(name=None, parameters=self.job_parameters)
 
         self.update_basic(user, name, description, tags)
+        self.execute = True
 
     def update_basic(self, user, name, description, tags):
         tags = list_of_strs(tags)
@@ -128,3 +129,6 @@ class DkubePreprocessing(object):
     def add_output_featureset(self, name, version=None, mountpath=None):
         featureset_model = JobInputFeaturesetModel(name=name, version=version, mountpath=mountpath)
         self.output_featuresets.append(featureset_model)
+
+    def disable_execution(self):
+        self.execute = False


### PR DESCRIPTION
- This fix is for DkubePreprocessing and DkubeServing (non training classes) which are also created using create_run()
- Such classes do not have an "execute" attribute since we are not providing the option to create them without execution.