### PR TITLE
Allow "Waiting for gpu" state in JobStatusModel

### DIFF
--- a/dkube/sdk/api.py
+++ b/dkube/sdk/api.py
@@ -243,7 +243,17 @@ class DkubeApi(ApiBase, FilesBase):
         super().update_tags(run.training_def)
         super().create_run(run)
         while wait_for_completion:
-            status = super().get_run('training', run.user, run.name, fields='status')
+            status = {}
+            try:
+                status = super().get_run('training', run.user, run.name, fields='status')
+            except ValueError as ve:
+                ve_without_num = ''.join(i for i in str(ve) if not i.isdigit())
+                if "Invalid value for `state` (Waiting for  gpu(s))" in ve_without_num:
+                    num = ''.join(i for i in str(ve) if i.isdigit())
+                    status['state'] = "Waiting for {} gpu(s)".format(num)
+                    status['reason'] = ""
+                else:
+                    raise ve
             state, reason = status['state'], status['reason']
             if state.lower() in ['complete', 'failed', 'error', 'stopped', 'created']:
                 print(


### PR DESCRIPTION
Fix for https://github.com/oneconvergence/gpuaas/issues/5937
This PR is to Ignore ValueError while creating training run if the error is due to state being "Waiting for (n) gpus".