### PR TITLE
Create model fix for new modelcatalog api

### DIFF
--- a/dkube/sdk/api.py
+++ b/dkube/sdk/api.py
@@ -1768,12 +1768,15 @@ class DkubeApi(ApiBase, FilesBase):
         assert stage_or_deploy in [
             "stage", "deploy"], "Invalid value for stage_or_deploy parameter."
 
-        mcitem = self.get_modelcatalog_item(
-            user, modelcatalog=model, version=version)
+        mcitem = super().get_model_catalog(user, model)
+        versions = mcitem['versions']
+        for v in versions:
+            if v['version'] == version:
+                serving_image = v['serving']['images']['serving']['image']['path']
+                
         run = DkubeServing(user, name=name, description=description)
         run.update_serving_model(model, version=version)
-        run.update_serving_image(image_url=mcitem['serving']['images'][
-                                 'serving']['image']['path'])
+        run.update_serving_image(serving_image)
         run.update_autoscaling_config(min_replicas, max_concurrent_requests)
 
         if stage_or_deploy == "stage":

--- a/dkube/sdk/api.py
+++ b/dkube/sdk/api.py
@@ -1768,16 +1768,21 @@ class DkubeApi(ApiBase, FilesBase):
         assert stage_or_deploy in [
             "stage", "deploy"], "Invalid value for stage_or_deploy parameter."
 
-        mcitem = super().get_model_catalog(user, model)
-        versions = mcitem['versions']
-        for v in versions:
-            if v['version'] == version:
-                serving_image = v['serving']['images']['serving']['image']['path']
-                
         run = DkubeServing(user, name=name, description=description)
         run.update_serving_model(model, version=version)
-        run.update_serving_image(image_url=serving_image)
         run.update_autoscaling_config(min_replicas, max_concurrent_requests)
+
+        dkubever = self.dkubeinfo['version']
+        if (pversion.parse(dkubever) < pversion.parse("2.3.0.0")):
+            mcitem = self.get_modelcatalog_item(user, modelcatalog=model, version=version)
+            run.update_serving_image(image_url=mcitem['serving']['images']['serving']['image']['path'])
+        else:
+            mcitem = super().get_model_catalog(user, model)
+            versions = mcitem['versions']
+            for v in versions:
+                if v['version'] == version:
+                    serving_image = v['serving']['images']['serving']['image']['path']
+            run.update_serving_image(image_url=serving_image)
 
         if stage_or_deploy == "stage":
             super().stage_model(run)

--- a/dkube/sdk/api.py
+++ b/dkube/sdk/api.py
@@ -1776,7 +1776,7 @@ class DkubeApi(ApiBase, FilesBase):
                 
         run = DkubeServing(user, name=name, description=description)
         run.update_serving_model(model, version=version)
-        run.update_serving_image(serving_image)
+        run.update_serving_image(image_url=serving_image)
         run.update_autoscaling_config(min_replicas, max_concurrent_requests)
 
         if stage_or_deploy == "stage":


### PR DESCRIPTION
create_model_deployment func modified for calling new modelcatalog API for serving image.

With this fix, create_deployment is passed. But robot test is using old get_modelcatalog API. 
robot test need to modify for this.
@hemanthravi 
 
![Screenshot from 2021-08-14 07-56-21](https://user-images.githubusercontent.com/69950815/129431776-d9ceacbf-d70b-4db6-922e-62efa56a667b.png)

[log.zip](https://github.com/oneconvergence/dkube/files/6985776/log.zip)
