### PR TITLE
Mlflow logger

### DIFF
--- a/dkube/sdk/mlflow_logger.py
+++ b/dkube/sdk/mlflow_logger.py
@@ -4,6 +4,7 @@ import mlflow
 import tempfile
 import os
 
+
 class DkubeMlflowLogger:
     def get_logger(self):
         logger = logging.getLogger()
@@ -11,20 +12,22 @@ class DkubeMlflowLogger:
             return logger
         else:
             logger.setLevel(logging.INFO)
-            log_formatter = logging.Formatter("%(asctime)s  %(name)s  |%(levelname)-5.5s|  %(message)s")
+            log_formatter = logging.Formatter(
+                "%(asctime)s  %(name)s  |%(levelname)-5.5s|  %(message)s")
             temp = tempfile.NamedTemporaryFile(suffix='.log', delete=False)
             file_handler = logging.FileHandler(temp.name)
             file_handler.setFormatter(log_formatter)
             logger.addHandler(file_handler)
-            
+
             console_handler = logging.StreamHandler(sys.stdout)
             console_handler.setFormatter(log_formatter)
             logger.addHandler(console_handler)
             return logger
-        
+
     def flush(self):
         logger = logging.getLogger()
-        log_paths = [handler.baseFilename for handler in logger.handlers if isinstance(handler, logging.FileHandler)]
+        log_paths = [handler.baseFilename for handler in logger.handlers if isinstance(
+            handler, logging.FileHandler)]
         log_file = next(iter(log_paths))
         if mlflow.active_run():
             print("Persisting logs in storage")
@@ -32,9 +35,3 @@ class DkubeMlflowLogger:
             os.remove(log_file)
         else:
             print("No active run found")
-        
-
-
-
-        
-    

--- a/dkube/sdk/mlflow_logger.py
+++ b/dkube/sdk/mlflow_logger.py
@@ -5,13 +5,13 @@ import tempfile
 import os
 
 
-class DkubeMlflowLogger:
-    def get_logger(self):
+class NotebookMlflowLogger:
+    def get_logger(self, level=logging.INFO):
         logger = logging.getLogger()
         if logger.handlers:
             return logger
         else:
-            logger.setLevel(logging.INFO)
+            logger.setLevel(level)
             log_formatter = logging.Formatter(
                 "%(asctime)s  %(name)s  |%(levelname)-5.5s|  %(message)s")
             temp = tempfile.NamedTemporaryFile(suffix='.log', delete=False)

--- a/dkube/sdk/mlflow_logger.py
+++ b/dkube/sdk/mlflow_logger.py
@@ -7,6 +7,8 @@ import os
 
 class NotebookMlflowLogger:
     def get_logger(self, level=logging.INFO):
+        if os.getenv("DKUBE_JOB_CLASS") != "notebook":
+            return logging.getLogger()
         logger = logging.getLogger()
         if logger.handlers:
             return logger
@@ -25,12 +27,13 @@ class NotebookMlflowLogger:
             return logger
 
     def flush(self):
+        if os.getenv("DKUBE_JOB_CLASS") != "notebook":
+            return
         logger = logging.getLogger()
         log_paths = [handler.baseFilename for handler in logger.handlers if isinstance(
             handler, logging.FileHandler)]
         log_file = next(iter(log_paths))
         if mlflow.active_run():
-            print("Persisting logs in storage")
             mlflow.log_artifact(log_file, "logs")
             os.remove(log_file)
         else:

--- a/dkube/sdk/mlflow_logger.py
+++ b/dkube/sdk/mlflow_logger.py
@@ -6,35 +6,39 @@ import os
 
 
 class NotebookMlflowLogger:
+    def __init__(self):
+        self.logger = None
+        self.filename = ""
+
     def get_logger(self, level=logging.INFO):
         if os.getenv("DKUBE_JOB_CLASS") != "notebook":
             return logging.getLogger()
         logger = logging.getLogger()
-        if logger.handlers:
-            return logger
-        else:
-            logger.setLevel(level)
-            log_formatter = logging.Formatter(
-                "%(asctime)s  %(name)s  |%(levelname)-5.5s|  %(message)s")
-            temp = tempfile.NamedTemporaryFile(suffix='.log', delete=False)
-            file_handler = logging.FileHandler(temp.name)
-            file_handler.setFormatter(log_formatter)
-            logger.addHandler(file_handler)
+        logger.handlers.clear()
+        logger.setLevel(level)
+        log_formatter = logging.Formatter(
+            "%(asctime)s  %(name)s  |%(levelname)-5.5s|  %(message)s")
+        temp = tempfile.NamedTemporaryFile(suffix='.log', delete=False)
+        self.filename = temp.name
+        file_handler = logging.FileHandler(temp.name)
+        file_handler.setFormatter(log_formatter)
+        logger.addHandler(file_handler)
 
-            console_handler = logging.StreamHandler(sys.stdout)
-            console_handler.setFormatter(log_formatter)
-            logger.addHandler(console_handler)
-            return logger
+        console_handler = logging.StreamHandler(sys.stdout)
+        console_handler.setFormatter(log_formatter)
+        logger.addHandler(console_handler)
+        self.logger = logger
+        return logger
 
     def flush(self):
         if os.getenv("DKUBE_JOB_CLASS") != "notebook":
             return
-        logger = logging.getLogger()
-        log_paths = [handler.baseFilename for handler in logger.handlers if isinstance(
-            handler, logging.FileHandler)]
-        log_file = next(iter(log_paths))
+
         if mlflow.active_run():
-            mlflow.log_artifact(log_file, "logs")
-            os.remove(log_file)
+            try:
+                mlflow.log_artifact(self.filename, "logs")
+                os.remove(self.filename)
+            except Exception as e:
+                print("Failed to capture logs", e)
         else:
             print("No active run found")

--- a/dkube/sdk/mlflow_logger.py
+++ b/dkube/sdk/mlflow_logger.py
@@ -1,0 +1,40 @@
+import logging
+import sys
+import mlflow
+import tempfile
+import os
+
+class DkubeMlflowLogger:
+    def get_logger(self):
+        logger = logging.getLogger()
+        if logger.handlers:
+            return logger
+        else:
+            logger.setLevel(logging.INFO)
+            log_formatter = logging.Formatter("%(asctime)s  %(name)s  |%(levelname)-5.5s|  %(message)s")
+            temp = tempfile.NamedTemporaryFile(suffix='.log', delete=False)
+            file_handler = logging.FileHandler(temp.name)
+            file_handler.setFormatter(log_formatter)
+            logger.addHandler(file_handler)
+            
+            console_handler = logging.StreamHandler(sys.stdout)
+            console_handler.setFormatter(log_formatter)
+            logger.addHandler(console_handler)
+            return logger
+        
+    def flush(self):
+        logger = logging.getLogger()
+        log_paths = [handler.baseFilename for handler in logger.handlers if isinstance(handler, logging.FileHandler)]
+        log_file = next(iter(log_paths))
+        if mlflow.active_run():
+            print("Persisting logs in storage")
+            mlflow.log_artifact(log_file, "logs")
+            os.remove(log_file)
+        else:
+            print("No active run found")
+        
+
+
+
+        
+    


### PR DESCRIPTION
Usage:
```
import mlflow
from dkube.sdk.mlflow_logger import NotebookMlflowLogger
nblogger = NotebookMlflowLogger()
logger = nblogger.get_logger()


with mlflow.start_run(run_name="insurance") as run:
    logger.info("complete")
    nblogger.flush()
```